### PR TITLE
Fixci

### DIFF
--- a/.github/workflows/validate-transforms-json.yml
+++ b/.github/workflows/validate-transforms-json.yml
@@ -1,4 +1,4 @@
-name: Validate Transforms
+name: Validate Transforms - JSON
 
 on:
   push:

--- a/.github/workflows/validate-transforms-json.yml
+++ b/.github/workflows/validate-transforms-json.yml
@@ -1,0 +1,40 @@
+name: Validate Transforms
+
+on:
+  push:
+#  schedule:
+#    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download validator_cli
+        run: wget https://github.com/hapifhir/org.hl7.fhir.core/releases/latest/download/validator_cli.jar
+
+      - name: Setup java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+      - run: pip install -r tests/requirements.txt;
+
+      - name: Unpack FHIR xver package
+        if: "!contains(github.event.head_commit.message, '[skip package mod]')"
+        run: |
+          mkdir -p ~/.fhir/package-client; \
+          mkdir -p ~/.fhir/packages/hl7.fhir.xver.r4#1.2.0; \
+          touch ~/.fhir/package-client/packages.fhir.org-hl7.fhir.xver.r4-1.2.0.tgz; \
+          tar -zxf packages/hl7.fhir.xver.r4#1.2.0-mod/package.tgz --directory ~/.fhir/packages/hl7.fhir.xver.r4#1.2.0
+
+      - name: Run tests
+        run: py.test -vv tests/validate_transforms/test_validate_transforms_json.py

--- a/.github/workflows/validate-transforms-xml.yml
+++ b/.github/workflows/validate-transforms-xml.yml
@@ -37,4 +37,4 @@ jobs:
           tar -zxf packages/hl7.fhir.xver.r4#1.2.0-mod/package.tgz --directory ~/.fhir/packages/hl7.fhir.xver.r4#1.2.0
 
       - name: Run tests
-        run: py.test -vv
+        run: py.test -vv tests/validate_transforms/test_validate_transforms_xml.py

--- a/.github/workflows/validate-transforms-xml.yml
+++ b/.github/workflows/validate-transforms-xml.yml
@@ -1,4 +1,4 @@
-name: Validate Transforms
+name: Validate Transforms - XML
 
 on:
   push:

--- a/examples/expected/communication-example-fm-attachment(fm-attachment).xml
+++ b/examples/expected/communication-example-fm-attachment(fm-attachment).xml
@@ -25,7 +25,7 @@
   </recipient>
   <extension url="http://hl7.org/fhir/3.0/StructureDefinition/extension-Communication.topic">
     <valueReference>
-    <!--   reference value="#claim"/   -->
+      <!--   reference value="#claim"/   -->
       <identifier>
         <system value="http://happyvalley.com/claim"/>
         <value value="12345"/>
@@ -34,7 +34,7 @@
   </extension>
   <extension url="http://hl7.org/fhir/3.0/StructureDefinition/extension-Communication.topic">
     <valueReference>
-    <!--   reference value="#claimresponse"/   -->
+      <!--   reference value="#claimresponse"/   -->
       <identifier>
         <system value="http://www.BenefitsInc.com/fhir/claimresponse"/>
         <value value="R3500"/>

--- a/tests/validate_transforms/test_validate_transforms_json.py
+++ b/tests/validate_transforms/test_validate_transforms_json.py
@@ -1,0 +1,25 @@
+import pytest
+import os
+import filecmp
+from .lib import common
+
+EXAMPLES_PATH = os.path.dirname(os.path.realpath(__file__)) + '/../../examples/input/'
+TRANSFORMED_PATH = './expected-'
+
+json_examples = common.get_input_files(EXAMPLES_PATH, '.json')
+
+@pytest.mark.parametrize("input_file", json_examples)
+def test_json_transforms(input_file):
+    transformed_file = TRANSFORMED_PATH + os.path.basename(input_file)
+
+    # Run transform
+    common.call_validator_cli(input_file)
+    assert os.path.exists(transformed_file)
+
+    # Sort json to prepare for simple comparison
+    [transformed, expected] = common.sort_json_files(input_file)
+    common.remove_files([transformed_file])      # Clean up transformed file
+
+    # Test transformed matches expected
+    assert transformed == expected
+

--- a/tests/validate_transforms/test_validate_transforms_xml.py
+++ b/tests/validate_transforms/test_validate_transforms_xml.py
@@ -6,23 +6,7 @@ from .lib import common
 EXAMPLES_PATH = os.path.dirname(os.path.realpath(__file__)) + '/../../examples/input/'
 TRANSFORMED_PATH = './expected-'
 
-json_examples = common.get_input_files(EXAMPLES_PATH, '.json')
 xml_examples = common.get_input_files(EXAMPLES_PATH, '.xml')
-
-@pytest.mark.parametrize("input_file", json_examples)
-def test_json_transforms(input_file):
-    transformed_file = TRANSFORMED_PATH + os.path.basename(input_file)
-
-    # Run transform
-    common.call_validator_cli(input_file)
-    assert os.path.exists(transformed_file)
-
-    # Sort json to prepare for simple comparison
-    [transformed, expected] = common.sort_json_files(input_file)
-    common.remove_files([transformed_file])      # Clean up transformed file
-
-    # Test transformed matches expected
-    assert transformed == expected
 
 @pytest.mark.parametrize("input_file", xml_examples)
 def test_xml_transforms(input_file):


### PR DESCRIPTION
Pipeline that was processing all the examples was timing out, so split up into two separate pipelines for xml and json.  All are still being transformed as expected.  

Although there was a minor change in the whitespace for a single XML transform.  I don't think making ignore whitespace is worth adding in that diff, as it is easily fixed and possibly worth noticing if/when it happens.  

Also disabled the scheduled run as no point in burning so much electricity for this...